### PR TITLE
fix move message: fixed indent at the inscription #127

### DIFF
--- a/components/GameField/GameField.module.scss
+++ b/components/GameField/GameField.module.scss
@@ -313,7 +313,7 @@
       font-weight: 600;
 
       @media (max-width: 576px) {
-        top: 2.5rem;
+        top: 1rem;
       }
     }
   }


### PR DESCRIPTION
the inscription does not appear on the playing field
![image](https://user-images.githubusercontent.com/109285732/215442238-5c089533-96ae-43ae-9b7c-b88d43717725.png)
